### PR TITLE
CI/Iopenapi doc

### DIFF
--- a/.github/workflows/api-doc.yaml
+++ b/.github/workflows/api-doc.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: Legion2/swagger-ui-action@v1
         with:
           output: swagger-ui
-          spec-url: http://localhost:3000/api
+          spec-file: swagger.json
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/api-doc.yaml
+++ b/.github/workflows/api-doc.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           node-version: '16'
       - run: yarn install
-      - run: yarn start
+      - run: yarn test:e2e
       - name: Generate Swagger UI
         uses: Legion2/swagger-ui-action@v1
         with:

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,6 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './../src/app.module';
+import * as path from 'path';
+import * as fs from 'fs';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
@@ -12,5 +15,21 @@ describe('AppController (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should generate swagger spec', async () => {
+    const config = new DocumentBuilder()
+      .setTitle('SYNC API')
+      .setDescription('The SYNC API spec')
+      .setVersion('2.0')
+      .build();
+
+    const document = SwaggerModule.createDocument(app, config);
+    const outputPath = path.resolve(process.cwd(), 'swagger.json');
+    fs.writeFileSync(outputPath, JSON.stringify(document));
   });
 });


### PR DESCRIPTION
Use e2e test to generate swagger UI.

ref: [How to generate openapi specification with nestjs without running the application](https://stackoverflow.com/questions/64927411/how-to-generate-openapi-specification-with-nestjs-without-running-the-applicatio)